### PR TITLE
[FEAT] 엔티티 설계 및 swagger, API 응답 통일, 에러 핸들러 생성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/src/main/java/spring/flink/FlinkApplication.java
+++ b/src/main/java/spring/flink/FlinkApplication.java
@@ -2,8 +2,15 @@ package spring.flink;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = SecurityAutoConfiguration.class)
+@EnableJpaAuditing
+@EnableJpaRepositories
+@EnableScheduling
 public class FlinkApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/spring/flink/apiPayload/ApiResponse.java
+++ b/src/main/java/spring/flink/apiPayload/ApiResponse.java
@@ -1,0 +1,37 @@
+package spring.flink.apiPayload;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import spring.flink.apiPayload.code.BaseCode;
+import spring.flink.apiPayload.code.status.SuccessStatus;
+
+@Getter
+@AllArgsConstructor
+@JsonPropertyOrder({"isSuccess", "code", "message", "result"})
+public class ApiResponse <T> {
+
+    @JsonProperty("isSuccess")
+    private final Boolean isSuccess;
+
+    private final String code;
+
+    private final String message;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private T result;
+
+    //성공한 경우 응답
+    public static <T> ApiResponse<T> onSuccess(T result) {
+        return new ApiResponse<>(true, SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), result);
+    }
+
+    public static <T> ApiResponse<T> of(BaseCode code, T result) {
+        return new ApiResponse<>(true, code.getReasonHttpStatus().getCode(), code.getReasonHttpStatus().getMessage(), result);
+    }
+    public static <T> ApiResponse<T> onFailure(String code, String message, T data) {
+        return new ApiResponse<>(false, code, message, data);
+    }
+}

--- a/src/main/java/spring/flink/apiPayload/code/BaseCode.java
+++ b/src/main/java/spring/flink/apiPayload/code/BaseCode.java
@@ -1,0 +1,8 @@
+package spring.flink.apiPayload.code;
+
+public interface BaseCode {
+
+    public ReasonDTO getReason();
+
+    public ReasonDTO getReasonHttpStatus();
+}

--- a/src/main/java/spring/flink/apiPayload/code/BaseErrorCode.java
+++ b/src/main/java/spring/flink/apiPayload/code/BaseErrorCode.java
@@ -1,0 +1,8 @@
+package spring.flink.apiPayload.code;
+
+public interface BaseErrorCode {
+
+    public ErrorReasonDTO getReason();
+
+    public ErrorReasonDTO getReasonHttpStatus();
+}

--- a/src/main/java/spring/flink/apiPayload/code/ErrorReasonDTO.java
+++ b/src/main/java/spring/flink/apiPayload/code/ErrorReasonDTO.java
@@ -1,0 +1,18 @@
+package spring.flink.apiPayload.code;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class ErrorReasonDTO {
+
+    private HttpStatus httpStatus;
+
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+
+    public boolean getIsSuccess(){return isSuccess;}
+}

--- a/src/main/java/spring/flink/apiPayload/code/ReasonDTO.java
+++ b/src/main/java/spring/flink/apiPayload/code/ReasonDTO.java
@@ -1,0 +1,18 @@
+package spring.flink.apiPayload.code;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class ReasonDTO {
+
+    private HttpStatus httpStatus;
+
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+
+    public boolean getIsSuccess(){return isSuccess;}
+}

--- a/src/main/java/spring/flink/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/spring/flink/apiPayload/code/status/ErrorStatus.java
@@ -1,0 +1,51 @@
+package spring.flink.apiPayload.code.status;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import spring.flink.apiPayload.code.BaseErrorCode;
+import spring.flink.apiPayload.code.ErrorReasonDTO;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorStatus implements BaseErrorCode {
+
+    // 가장 일반적인 응답
+    _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
+    _BAD_REQUEST(HttpStatus.BAD_REQUEST,"COMMON400","잘못된 요청입니다."),
+    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
+
+
+    // 멤버 관려 에러
+    MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER4001", "사용자가 없습니다."),
+    NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "MEMBER4002", "닉네임은 필수 입니다."),
+
+    // 예시,,,
+    ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "ARTICLE4001", "게시글이 없습니다.");
+
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReasonDTO getReason() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .build();
+    }
+
+    @Override
+    public ErrorReasonDTO getReasonHttpStatus() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .build()
+                ;
+    }
+}

--- a/src/main/java/spring/flink/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/spring/flink/apiPayload/code/status/SuccessStatus.java
@@ -1,0 +1,39 @@
+package spring.flink.apiPayload.code.status;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import spring.flink.apiPayload.code.BaseCode;
+import spring.flink.apiPayload.code.ReasonDTO;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessStatus implements BaseCode {
+
+    // 일반적인 응답
+    _OK(HttpStatus.OK, "COMMON200", "성공입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ReasonDTO getReason() {
+        return ReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(true)
+                .build();
+    }
+
+    @Override
+    public ReasonDTO getReasonHttpStatus() {
+        return ReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(true)
+                .httpStatus(httpStatus)
+                .build()
+                ;
+    }
+}

--- a/src/main/java/spring/flink/apiPayload/exception/ExceptionAdvice.java
+++ b/src/main/java/spring/flink/apiPayload/exception/ExceptionAdvice.java
@@ -1,0 +1,120 @@
+package spring.flink.apiPayload.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import spring.flink.apiPayload.ApiResponse;
+import spring.flink.apiPayload.code.ErrorReasonDTO;
+import spring.flink.apiPayload.code.status.ErrorStatus;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+@RestControllerAdvice(annotations = {RestController.class})
+public class ExceptionAdvice extends ResponseEntityExceptionHandler {
+
+
+    @org.springframework.web.bind.annotation.ExceptionHandler
+    public ResponseEntity<Object> validation(ConstraintViolationException e, WebRequest request) {
+        String errorMessage = e.getConstraintViolations().stream()
+                .map(constraintViolation -> constraintViolation.getMessage())
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("ConstraintViolationException 추출 도중 에러 발생"));
+
+        return handleExceptionInternalConstraint(e, ErrorStatus.valueOf(errorMessage), HttpHeaders.EMPTY,request);
+    }
+
+    @Override
+    public ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException e, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+
+        Map<String, String> errors = new LinkedHashMap<>();
+
+        e.getBindingResult().getFieldErrors().stream()
+                .forEach(fieldError -> {
+                    String fieldName = fieldError.getField();
+                    String errorMessage = Optional.ofNullable(fieldError.getDefaultMessage()).orElse("");
+                    errors.merge(fieldName, errorMessage, (existingErrorMessage, newErrorMessage) -> existingErrorMessage + ", " + newErrorMessage);
+                });
+
+        return handleExceptionInternalArgs(e,HttpHeaders.EMPTY,ErrorStatus.valueOf("_BAD_REQUEST"),request,errors);
+    }
+
+    @org.springframework.web.bind.annotation.ExceptionHandler
+    public ResponseEntity<Object> exception(Exception e, WebRequest request) {
+        e.printStackTrace();
+
+        return handleExceptionInternalFalse(e, ErrorStatus._INTERNAL_SERVER_ERROR, HttpHeaders.EMPTY, ErrorStatus._INTERNAL_SERVER_ERROR.getHttpStatus(),request, e.getMessage());
+    }
+
+    @ExceptionHandler(value = GeneralException.class)
+    public ResponseEntity onThrowException(GeneralException generalException, HttpServletRequest request) {
+        ErrorReasonDTO errorReasonHttpStatus = generalException.getErrorReasonHttpStatus();
+        return handleExceptionInternal(generalException,errorReasonHttpStatus,null,request);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(Exception e, ErrorReasonDTO reason,
+                                                           HttpHeaders headers, HttpServletRequest request) {
+
+        ApiResponse<Object> body = ApiResponse.onFailure(reason.getCode(),reason.getMessage(),null);
+//        e.printStackTrace();
+
+        WebRequest webRequest = new ServletWebRequest(request);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                reason.getHttpStatus(),
+                webRequest
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalFalse(Exception e, ErrorStatus errorCommonStatus,
+                                                                HttpHeaders headers, HttpStatus status, WebRequest request, String errorPoint) {
+        ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(),errorCommonStatus.getMessage(),errorPoint);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                status,
+                request
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalArgs(Exception e, HttpHeaders headers, ErrorStatus errorCommonStatus,
+                                                               WebRequest request, Map<String, String> errorArgs) {
+        ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(),errorCommonStatus.getMessage(),errorArgs);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                errorCommonStatus.getHttpStatus(),
+                request
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalConstraint(Exception e, ErrorStatus errorCommonStatus,
+                                                                     HttpHeaders headers, WebRequest request) {
+        ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(), errorCommonStatus.getMessage(), null);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                errorCommonStatus.getHttpStatus(),
+                request
+        );
+    }
+}

--- a/src/main/java/spring/flink/apiPayload/exception/GeneralException.java
+++ b/src/main/java/spring/flink/apiPayload/exception/GeneralException.java
@@ -1,0 +1,20 @@
+package spring.flink.apiPayload.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import spring.flink.apiPayload.code.BaseErrorCode;
+import spring.flink.apiPayload.code.ErrorReasonDTO;
+
+@Getter
+@AllArgsConstructor
+public class GeneralException extends RuntimeException {
+    private BaseErrorCode code;
+
+    public ErrorReasonDTO getErrorReason() {
+        return this.code.getReason();
+    }
+
+    public ErrorReasonDTO getErrorReasonHttpStatus() {
+        return this.code.getReasonHttpStatus();
+    }
+}

--- a/src/main/java/spring/flink/apiPayload/exception/handler/TempHandler.java
+++ b/src/main/java/spring/flink/apiPayload/exception/handler/TempHandler.java
@@ -1,0 +1,11 @@
+package spring.flink.apiPayload.exception.handler;
+
+import spring.flink.apiPayload.code.BaseErrorCode;
+import spring.flink.apiPayload.exception.GeneralException;
+
+public class TempHandler extends GeneralException {
+
+    public TempHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/spring/flink/config/SwaggerConfig.java
+++ b/src/main/java/spring/flink/config/SwaggerConfig.java
@@ -1,0 +1,39 @@
+package spring.flink.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI FlinkAPI() {
+        Info info = new Info()
+                .title("Flink Backend API")
+                .description("Flink Backend API 명세서")
+                .version("1.0.0");
+
+        String jwtSchemeName = "JWT TOKEN";
+        // API 요청헤더에 인증정보 포함
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
+        // SecuritySchemes 등록
+        Components components = new Components()
+                .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
+                        .name(jwtSchemeName)
+                        .type(SecurityScheme.Type.HTTP) // HTTP 방식
+                        .scheme("bearer")
+                        .bearerFormat("JWT"));
+
+        return new OpenAPI()
+                .addServersItem(new Server().url("/"))
+                .info(info)
+                .addSecurityItem(securityRequirement)
+                .components(components);
+    }
+}

--- a/src/main/java/spring/flink/config/tempConfig.java
+++ b/src/main/java/spring/flink/config/tempConfig.java
@@ -1,4 +1,0 @@
-package spring.flink.config;
-
-public class tempConfig {
-}

--- a/src/main/java/spring/flink/domain/ChatPart.java
+++ b/src/main/java/spring/flink/domain/ChatPart.java
@@ -1,0 +1,24 @@
+package spring.flink.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+import spring.flink.domain.common.BaseEntity;
+
+@Entity
+@Getter
+@Builder
+@DynamicUpdate
+@DynamicInsert
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatPart extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+}

--- a/src/main/java/spring/flink/domain/ChattingRoom.java
+++ b/src/main/java/spring/flink/domain/ChattingRoom.java
@@ -1,0 +1,27 @@
+package spring.flink.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+import spring.flink.domain.common.BaseEntity;
+import spring.flink.domain.enums.ChattingRoomStatus;
+
+@Entity
+@Getter
+@Builder
+@DynamicUpdate
+@DynamicInsert
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChattingRoom extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String roomName;
+
+    @Enumerated(EnumType.STRING)
+    private ChattingRoomStatus chattingRoomStatus;
+}

--- a/src/main/java/spring/flink/domain/Comment.java
+++ b/src/main/java/spring/flink/domain/Comment.java
@@ -1,0 +1,33 @@
+package spring.flink.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+import spring.flink.domain.common.BaseEntity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Builder
+@DynamicUpdate
+@DynamicInsert
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Comment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private Comment parent;
+
+    @OneToMany(mappedBy = "parent")
+    private List<Comment> children = new ArrayList<>();
+}

--- a/src/main/java/spring/flink/domain/Message.java
+++ b/src/main/java/spring/flink/domain/Message.java
@@ -1,0 +1,26 @@
+package spring.flink.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+import spring.flink.domain.common.BaseEntity;
+
+@Entity
+@Getter
+@Builder
+@DynamicUpdate
+@DynamicInsert
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Message extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String detailMessage;
+}

--- a/src/main/java/spring/flink/domain/Post.java
+++ b/src/main/java/spring/flink/domain/Post.java
@@ -1,0 +1,34 @@
+package spring.flink.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+import spring.flink.domain.common.BaseEntity;
+
+@Entity
+@Getter
+@Builder
+@DynamicUpdate
+@DynamicInsert
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Post extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    private String content;
+
+    private Long likes;
+
+    private Long comments;
+
+    private Long views;
+}

--- a/src/main/java/spring/flink/domain/PostLikes.java
+++ b/src/main/java/spring/flink/domain/PostLikes.java
@@ -1,0 +1,24 @@
+package spring.flink.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+import spring.flink.domain.common.BaseEntity;
+
+@Entity
+@Getter
+@Builder
+@DynamicUpdate
+@DynamicInsert
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostLikes extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+}

--- a/src/main/java/spring/flink/domain/Project.java
+++ b/src/main/java/spring/flink/domain/Project.java
@@ -1,0 +1,45 @@
+package spring.flink.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+import spring.flink.domain.common.BaseEntity;
+import spring.flink.domain.enums.Occupation;
+import spring.flink.domain.enums.ProjectStatus;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@DynamicUpdate
+@DynamicInsert
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Project extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    private Occupation occupation;
+
+    @Enumerated(EnumType.STRING)
+    private ProjectStatus projectStatus;
+
+    private Long recruitMemberCount;
+
+    private Long registerMemberCount;
+
+    private Long views;
+
+    private LocalDateTime recruitStartedAt;
+
+    private LocalDateTime recruitEndedAt;
+}

--- a/src/main/java/spring/flink/domain/Registration.java
+++ b/src/main/java/spring/flink/domain/Registration.java
@@ -1,0 +1,25 @@
+package spring.flink.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+import spring.flink.domain.common.BaseEntity;
+import spring.flink.domain.enums.RegistrationStatus;
+
+@Entity
+@Getter
+@Builder
+@DynamicUpdate
+@DynamicInsert
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Registration extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private RegistrationStatus registrationStatus;
+}

--- a/src/main/java/spring/flink/domain/common/BaseEntity.java
+++ b/src/main/java/spring/flink/domain/common/BaseEntity.java
@@ -1,4 +1,4 @@
-package spring.flink.common;
+package spring.flink.domain.common;
 
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;

--- a/src/main/java/spring/flink/domain/enums/ChattingRoomStatus.java
+++ b/src/main/java/spring/flink/domain/enums/ChattingRoomStatus.java
@@ -1,0 +1,5 @@
+package spring.flink.domain.enums;
+
+public enum ChattingRoomStatus {
+    OPEN, CLOSED
+}

--- a/src/main/java/spring/flink/domain/enums/Occupation.java
+++ b/src/main/java/spring/flink/domain/enums/Occupation.java
@@ -1,0 +1,5 @@
+package spring.flink.domain.enums;
+
+public enum Occupation {
+    PM, DESIGNER, FRONTEND, BACKEND
+}

--- a/src/main/java/spring/flink/domain/enums/ProjectStatus.java
+++ b/src/main/java/spring/flink/domain/enums/ProjectStatus.java
@@ -1,0 +1,5 @@
+package spring.flink.domain.enums;
+
+public enum ProjectStatus {
+    OPEN, CLOSED
+}

--- a/src/main/java/spring/flink/domain/enums/RegistrationStatus.java
+++ b/src/main/java/spring/flink/domain/enums/RegistrationStatus.java
@@ -1,0 +1,5 @@
+package spring.flink.domain.enums;
+
+public enum RegistrationStatus {
+    ONGOING, APPROVED, REJECTED
+}

--- a/src/main/java/spring/flink/domain/tempDomain.java
+++ b/src/main/java/spring/flink/domain/tempDomain.java
@@ -1,4 +1,0 @@
-package spring.flink.domain;
-
-public class tempDomain {
-}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=flink

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,19 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/flink
+    username: root
+    password: mysql
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  sql:
+    init:
+      mode: never
+  jpa:
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQL8Dialect
+        show_sql: true
+        format_sql: true
+        use_sql_comments: true
+        hbm2ddl:
+          auto: update
+        default_batch_fetch_size: 1000


### PR DESCRIPTION
## 💡 관련 이슈
 - #1

## 📢 작업 내용
 - Entity 생성 (ChatPart, ChattingRoom, Comment, Message, Post, PostLikes, Project, Registration)
 - Enums 생성 (ChattingRoomStatus, Occupation, ProjectStatus, RegistrationStatus)
 - Swagger 관련 코드 추가
 - API 응답 통일 및 에러 핸들러 관련 코드 추가
 - build.gradle에 validation, webmvc-ui 추가
 - application.yml 작성
 - 임시 클래스 삭제

## 🗨️ 리뷰 요구 사항(선택)
 - X

## ✅ 체크 리스트
 - [x] 코드가 정상적으로 컴파일되나요?
 - [x] 이슈 내용을 전부 구현했나요?
 - [x] 작업 기간 내에 개발을 완료했나요?
 - [ ] 리뷰어를 선택했나요?
 - [x] 라벨을 지정했나요?
