### PR TITLE
[FIX] Entity 연관관계 매핑 및 필드명과 타입 수정

### DIFF
--- a/src/main/java/spring/flink/domain/Alarm.java
+++ b/src/main/java/spring/flink/domain/Alarm.java
@@ -33,4 +33,8 @@ public class Alarm extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private AlarmType type;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
 }

--- a/src/main/java/spring/flink/domain/Block.java
+++ b/src/main/java/spring/flink/domain/Block.java
@@ -1,9 +1,6 @@
 package spring.flink.domain;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
@@ -22,5 +19,11 @@ public class Block extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "target_id")
+    private Member target;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "owner_id")
+    private Member owner;
 }

--- a/src/main/java/spring/flink/domain/ChatPart.java
+++ b/src/main/java/spring/flink/domain/ChatPart.java
@@ -1,13 +1,13 @@
 package spring.flink.domain;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 import spring.flink.domain.common.BaseEntity;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -21,4 +21,16 @@ public class ChatPart extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "registration_id")
+    private Registration registration;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chatting_room_id")
+    private ChattingRoom chattingRoom;
+
+    @OneToMany(mappedBy = "chatPart", cascade = CascadeType.ALL)
+    @Builder.Default
+    private List<Message> messageList = new ArrayList<>();
 }

--- a/src/main/java/spring/flink/domain/ChattingRoom.java
+++ b/src/main/java/spring/flink/domain/ChattingRoom.java
@@ -7,6 +7,9 @@ import org.hibernate.annotations.DynamicUpdate;
 import spring.flink.domain.common.BaseEntity;
 import spring.flink.domain.enums.ChattingRoomStatus;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
 @Builder
@@ -25,4 +28,8 @@ public class ChattingRoom extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     private ChattingRoomStatus status;
+
+    @OneToMany(mappedBy = "chattingRoom", cascade = CascadeType.ALL)
+    @Builder.Default
+    private List<ChatPart> chatPartList = new ArrayList<>();
 }

--- a/src/main/java/spring/flink/domain/Comment.java
+++ b/src/main/java/spring/flink/domain/Comment.java
@@ -30,5 +30,6 @@ public class Comment extends BaseEntity {
     private Comment parent;
 
     @OneToMany(mappedBy = "parent")
+    @Builder.Default
     private List<Comment> children = new ArrayList<>();
 }

--- a/src/main/java/spring/flink/domain/Inquiry.java
+++ b/src/main/java/spring/flink/domain/Inquiry.java
@@ -8,6 +8,9 @@ import spring.flink.domain.common.BaseEntity;
 import spring.flink.domain.enums.InquiryStatus;
 import spring.flink.domain.enums.InquiryType;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
 @Builder
@@ -35,5 +38,11 @@ public class Inquiry extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private InquiryStatus status;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
 
+    @OneToMany(mappedBy = "inquiry", cascade = CascadeType.ALL)
+    @Builder.Default
+    private List<InquiryImage> inquiryImageList = new ArrayList<>();
 }

--- a/src/main/java/spring/flink/domain/InquiryImage.java
+++ b/src/main/java/spring/flink/domain/InquiryImage.java
@@ -1,9 +1,6 @@
 package spring.flink.domain;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
@@ -22,7 +19,13 @@ public class InquiryImage extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(columnDefinition = "TEXT")
     private String imageUrl;
 
+    @Column(columnDefinition = "TEXT")
     private String imageName;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "inquiry_id")
+    private Inquiry inquiry;
 }

--- a/src/main/java/spring/flink/domain/Member.java
+++ b/src/main/java/spring/flink/domain/Member.java
@@ -8,6 +8,8 @@ import spring.flink.domain.common.BaseEntity;
 import spring.flink.domain.enums.MemberStatus;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -43,4 +45,23 @@ public class Member extends BaseEntity {
     @Column(nullable = false)
     private MemberStatus status;
 
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    @Builder.Default
+    private List<Alarm> alarmList = new ArrayList<>();
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "profile_id")
+    private Profile profile;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    @Builder.Default
+    private List<Inquiry> inquiryList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    @Builder.Default
+    private List<PostLikes> postLikesList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    @Builder.Default
+    private List<Registration> registrationList = new ArrayList<>();
 }

--- a/src/main/java/spring/flink/domain/Message.java
+++ b/src/main/java/spring/flink/domain/Message.java
@@ -21,4 +21,8 @@ public class Message extends BaseEntity {
 
     @Column(nullable = false, columnDefinition = "varchar(255)")
     private String detailMessage;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_part_id")
+    private ChatPart chatPart;
 }

--- a/src/main/java/spring/flink/domain/Post.java
+++ b/src/main/java/spring/flink/domain/Post.java
@@ -6,6 +6,9 @@ import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 import spring.flink.domain.common.BaseEntity;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
 @Builder
@@ -33,4 +36,8 @@ public class Post extends BaseEntity {
 
     @Column(nullable = false, columnDefinition = "BIGINT DEFAULT 0")
     private Long views;
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
+    @Builder.Default
+    private List<PostLikes> postLikesList = new ArrayList<>();
 }

--- a/src/main/java/spring/flink/domain/PostImage.java
+++ b/src/main/java/spring/flink/domain/PostImage.java
@@ -1,9 +1,6 @@
 package spring.flink.domain;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
@@ -22,8 +19,13 @@ public class PostImage extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(columnDefinition = "TEXT")
     private String imageUrl;
 
+    @Column(columnDefinition = "TEXT")
     private String imageName;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
 }

--- a/src/main/java/spring/flink/domain/PostLikes.java
+++ b/src/main/java/spring/flink/domain/PostLikes.java
@@ -1,9 +1,6 @@
 package spring.flink.domain;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
@@ -21,4 +18,12 @@ public class PostLikes extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
 }

--- a/src/main/java/spring/flink/domain/Profile.java
+++ b/src/main/java/spring/flink/domain/Profile.java
@@ -23,8 +23,10 @@ public class Profile extends BaseEntity {
     @Column(nullable = false, columnDefinition = "varchar(50)")
     private String nickname;
 
-    private String url;
+    @Column(columnDefinition = "TEXT")
+    private String imageUrl;
 
+    @Column(columnDefinition = "TEXT")
     private String imageName;
 
     @Column(nullable = false)
@@ -34,8 +36,12 @@ public class Profile extends BaseEntity {
     @Column(nullable = false)
     private Occupation occupation;
 
+    @Column(columnDefinition = "TEXT")
     private String portfolioUrl;
 
+    @Column(columnDefinition = "TEXT")
     private String portfolioName;
 
+    @OneToOne(mappedBy = "profile", cascade = CascadeType.ALL)
+    private Member member;
 }

--- a/src/main/java/spring/flink/domain/Project.java
+++ b/src/main/java/spring/flink/domain/Project.java
@@ -9,6 +9,8 @@ import spring.flink.domain.enums.Occupation;
 import spring.flink.domain.enums.ProjectStatus;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -51,4 +53,8 @@ public class Project extends BaseEntity {
 
     @Column(nullable = false)
     private LocalDateTime recruitEndedAt;
+
+    @OneToMany(mappedBy = "project", cascade = CascadeType.ALL)
+    @Builder.Default
+    private List<Registration> registrationList = new ArrayList<>();
 }

--- a/src/main/java/spring/flink/domain/Registration.java
+++ b/src/main/java/spring/flink/domain/Registration.java
@@ -7,6 +7,9 @@ import org.hibernate.annotations.DynamicUpdate;
 import spring.flink.domain.common.BaseEntity;
 import spring.flink.domain.enums.RegistrationStatus;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
 @Builder
@@ -23,4 +26,16 @@ public class Registration extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private RegistrationStatus status;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id")
+    private Project project;
+
+    @OneToMany(mappedBy = "registration", cascade = CascadeType.ALL)
+    @Builder.Default
+    private List<ChatPart> chatPartList = new ArrayList<>();
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   datasource:
     url: jdbc:mysql://localhost:3306/flink
     username: root
-    password: 1234
+    password: mysql
     driver-class-name: com.mysql.cj.jdbc.Driver
   sql:
     init:
@@ -15,5 +15,8 @@ spring:
         format_sql: true
         use_sql_comments: true
         hbm2ddl:
-          auto: update
+          auto: create
         default_batch_fetch_size: 1000
+logging:
+  level:
+    org.hibernate.SQL: TRACE


### PR DESCRIPTION
## 💡 관련 이슈
 - #1 

## 📢 작업 내용
 - Entity 연관관계 매핑
   - 일대일 관계인 Profile과 Member에서 연관관계의 주인을 Member로 변경
   - 컬렉션에 @Builder.Default 애노테이션 설정
 - 이미지 관련 테이블 (InquiryImage, Profile, PostImage)
   - 필드명 수정: url -> imageUrl
   - URL과 파일명 필드를 TEXT 타입으로 설정

## 🗨️ 리뷰 요구 사항(선택)
 - X

## ✅ 체크 리스트
 - [x] 코드가 정상적으로 컴파일되나요?
 - [x] 이슈 내용을 전부 구현했나요?
 - [x] 작업 기간 내에 개발을 완료했나요?
 - [x] 리뷰어를 선택했나요?
 - [x] 라벨을 지정했나요?
